### PR TITLE
API age error and unordered visualisation fix

### DIFF
--- a/src/pubmetric/api_controller.py
+++ b/src/pubmetric/api_controller.py
@@ -121,7 +121,7 @@ async def score_workflow(cwl_file: UploadFile = File(None)):
         ages_output = []
         ages = []
         for tool_name, pmid in workflow['steps'].items():
-            age = next(tool['age'] for tool in graph.vs if tool['pmid'] == pmid)
+            age = next((tool['age'] for tool in graph.vs if tool['pmid'] == pmid), None)
             if not age or age > 40: # igraph requires all values of same type, hence >40 is None
                 age = "Unknown"
                 desirability = 0

--- a/src/pubmetric/workflow.py
+++ b/src/pubmetric/workflow.py
@@ -55,7 +55,7 @@ def parse_cwl(graph: igraph.Graph, cwl_filename: str) -> list:
         pmid_edges.append((str(source_pmid), str(target_pmid)))
 
     workflow = {"edges": edges,
-                "steps": workflow_steps, # steps and correspoding pmids
+                "steps": dict(sorted(workflow_steps.items(), key=lambda item: item[0][-2:])),   # steps and correspoding pmids, now ordered 
                 "pmid_edges": pmid_edges
     }
     return workflow

--- a/tests/data/candidate_workflow_repeated_tool.cwl
+++ b/tests/data/candidate_workflow_repeated_tool.cwl
@@ -15,25 +15,25 @@ inputs:
     format: "http://edamontology.org/format_1929" # FASTA
 steps:
   XTandem_01:
-    run: https://raw.githubusercontent.com/Workflomics/containers/main/cwl/tools/XTandem/XTandem.cwl
+    run: https://raw.githubusercontent.com/Workflomics/tools-and-domains/main/cwl-tools/xtandem/xtandem.cwl
     in:
       XTandem_in_1: input_1
       XTandem_in_2: input_2
     out: [XTandem_out_1]
   ProteinProphet_02:
-    run: https://raw.githubusercontent.com/Workflomics/containers/main/cwl/tools/ProteinProphet/ProteinProphet.cwl
+    run: https://raw.githubusercontent.com/Workflomics/tools-and-domains/main/cwl-tools/proteinprophet/proteinprophet.cwl
     in:
       ProteinProphet_in_1: XTandem_01/XTandem_out_1
       ProteinProphet_in_2: input_2
     out: [ProteinProphet_out_1, ProteinProphet_out_2]
   XTandem_03:
-    run: https://raw.githubusercontent.com/Workflomics/containers/main/cwl/tools/XTandem/XTandem.cwl
+    run: https://raw.githubusercontent.com/Workflomics/tools-and-domains/main/cwl-tools/xtandem/xtandem.cwl
     in:
       XTandem_in_1: input_1
       XTandem_in_2: input_2
     out: [XTandem_out_1]
   StPeter_04:
-    run: https://raw.githubusercontent.com/Workflomics/containers/main/cwl/tools/StPeter/StPeter.cwl
+    run: https://raw.githubusercontent.com/Workflomics/tools-and-domains/main/cwl-tools/stpeter/stpeter.cwl
     in:
       StPeter_in_1: ProteinProphet_02/ProteinProphet_out_1
       StPeter_in_2: XTandem_03/XTandem_out_1

--- a/tests/data/candidate_workflow_test.cwl
+++ b/tests/data/candidate_workflow_test.cwl
@@ -15,26 +15,26 @@ inputs:
     format: "http://edamontology.org/format_1929" # FASTA
 steps:
   XTandem_01:
-    run: https://raw.githubusercontent.com/Workflomics/containers/main/cwl/tools/XTandem/XTandem.cwl
+    run: https://raw.githubusercontent.com/Workflomics/tools-and-domains/main/cwl-tools/xtandem/xtandem.cwl
     in:
       XTandem_in_1: input_1
       XTandem_in_2: input_2
     out: [XTandem_out_1]
   ProteinProphet_02:
-    run: https://raw.githubusercontent.com/Workflomics/containers/main/cwl/tools/ProteinProphet/ProteinProphet.cwl
+    run: https://raw.githubusercontent.com/Workflomics/tools-and-domains/main/cwl-tools/proteinprophet/proteinprophet.cwl
     in:
       ProteinProphet_in_1: XTandem_01/XTandem_out_1
       ProteinProphet_in_2: input_2
     out: [ProteinProphet_out_1, ProteinProphet_out_2]
   PeptideProphet_03:
-    run: https://raw.githubusercontent.com/Workflomics/containers/main/cwl/tools/PeptideProphet/PeptideProphet.cwl
+    run: https://raw.githubusercontent.com/Workflomics/tools-and-domains/main/cwl-tools/peptideprophet/peptideprophet.cwl
     in:
       PeptideProphet_in_1: XTandem_01/XTandem_out_1
       PeptideProphet_in_2: input_1
       PeptideProphet_in_3: input_2
     out: [PeptideProphet_out_1, PeptideProphet_out_2]
   StPeter_04:
-    run: https://raw.githubusercontent.com/Workflomics/containers/main/cwl/tools/StPeter/StPeter.cwl
+    run: https://raw.githubusercontent.com/Workflomics/tools-and-domains/main/cwl-tools/stpeter/stpeter.cwl
     in:
       StPeter_in_1: ProteinProphet_02/ProteinProphet_out_1
       StPeter_in_2: PeptideProphet_03/PeptideProphet_out_1

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -20,7 +20,7 @@ def test_tool_level_average_sum(shared_datadir):
     workflow = parse_cwl(graph=graph , cwl_filename=cwl_filename)
     # graph = asyncio.run(create_network(inpath=shared_datadir, test_size=20, load_graph=True))
     tool_scores = met.tool_average_sum(graph, workflow)
-    assert list(tool_scores.keys()) == ['ProteinProphet_02', 'StPeter_04', 'XTandem_01', 'XTandem_03'] # note this only tests the format is right
+    assert list(tool_scores.keys()) == ['XTandem_01', 'ProteinProphet_02', 'XTandem_03', 'StPeter_04'] # note this only tests the format is right
     assert tool_scores['XTandem_01'] != tool_scores['XTandem_03']
 
 # The rest of the tests are based on the example graph


### PR DESCRIPTION
Fixing two errors:

1. Error with API response when there is no data for a tools age. fixed by making the age response value optional 
2. error when loading cwl object using cwl_utils.parser.load_document_by_uri() - returns steps alphabetically. Fixed by ordering by the workflomics provided stepid